### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           args: zip -X -r build/acf-component-manager.zip . -x *.git* node_modules/\* .* "*/\.*" CODE_OF_CONDUCT.md CONTRIBUTING.md ISSUE_TEMPLATE.md PULL_REQUEST_TEMPLATE.md *.dist composer.* dev-helpers** build**
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: acf-component-manager
           path: build/acf-component-manager.zip


### PR DESCRIPTION
actions/upload-artifact@v2 is long dead, v3 is deprecated, so on to v4?  Hopefully this works for a while.